### PR TITLE
WebGL addon should be disabled on safari

### DIFF
--- a/components/form/SerialConsole/index.vue
+++ b/components/form/SerialConsole/index.vue
@@ -25,6 +25,7 @@ export default {
       terminal:    null,
       fitAddon:    null,
       searchAddon: null,
+      webglAddon:  null,
       isOpen:      false,
       isOpening:   false,
       backlog:     [],
@@ -94,11 +95,21 @@ export default {
       this.fitAddon = new addons.fit.FitAddon();
       this.searchAddon = new addons.search.SearchAddon();
 
+      try {
+        this.webglAddon = new addons.webgl.WebGlAddon();
+      } catch (e) {
+        // Some browsers (Safari) don't support the webgl renderer, so don't use it.
+        this.webglAddon = null;
+      }
+
       terminal.loadAddon(this.fitAddon);
       terminal.loadAddon(this.searchAddon);
       terminal.loadAddon(new addons.weblinks.WebLinksAddon());
       terminal.open(this.$refs.xterm);
-      terminal.loadAddon(new addons.webgl.WebglAddon());
+
+      if ( this.webglAddon ) {
+        terminal.loadAddon(this.webglAddon);
+      }
 
       this.fit();
       this.flush();
@@ -203,6 +214,10 @@ export default {
     },
 
     fit(arg) {
+      if ( !this.fitAddon ) {
+        return;
+      }
+
       this.fitAddon.fit();
 
       const { rows, cols } = this.fitAddon.proposeDimensions();


### PR DESCRIPTION
## Linked Issues

[https://github.com/harvester/harvester/issues/859](https://github.com/harvester/harvester/issues/859)