### PR TITLE
hide edit option for server-version in ui

### DIFF
--- a/list/harvesterhci.io.setting.vue
+++ b/list/harvesterhci.io.setting.vue
@@ -121,7 +121,7 @@ export default {
           <h1>{{ setting.id }}<span v-if="setting.customized" class="modified">Modified</span></h1>
           <h2>{{ setting.description }}</h2>
         </div>
-        <div v-if="setting.hasActions" class="action">
+        <div v-if="setting.hasActions && setting.id != 'server-version'" class="action">
           <button aria-haspopup="true" aria-expanded="false" type="button" class="btn btn-sm role-multi-action actions" @click="showActionMenu($event, setting)">
             <i class="icon icon-actions" />
           </button>


### PR DESCRIPTION
This hides the edit button for server-version from the ui so a user can't accidentally change it. Its still possible to change it via api or directly entering the url for editing server-version.

issue: https://github.com/harvester/harvester/issues/1050